### PR TITLE
Add optional Pinch to Zoom for two-finger touch

### DIFF
--- a/MockTab/Driver/Injection/InjectionSnapshot.swift
+++ b/MockTab/Driver/Injection/InjectionSnapshot.swift
@@ -63,6 +63,7 @@ struct InjectionSnapshot: Sendable, Equatable {
     var twoFingerScroll: Bool
     var reverseScrollDirection: Bool
     var twoFingerScrollMomentum: Bool
+    var pinchZoomViaModifierWheel: Bool
     var touchAreaX: Double
     var touchAreaY: Double
     var touchAreaWidth: Double
@@ -142,6 +143,7 @@ extension TabletSettings {
             twoFingerScroll: twoFingerScroll,
             reverseScrollDirection: reverseScrollDirection,
             twoFingerScrollMomentum: twoFingerScrollMomentum,
+            pinchZoomViaModifierWheel: pinchZoomViaModifierWheel,
             touchAreaX: touchAreaX,
             touchAreaY: touchAreaY,
             touchAreaWidth: touchAreaWidth,

--- a/MockTab/Driver/Injection/InputInjector+Touch.swift
+++ b/MockTab/Driver/Injection/InputInjector+Touch.swift
@@ -61,7 +61,8 @@ extension InputInjector {
             if !contacts.isEmpty {
                 _ = touchTracker.process(
                     contacts: [], tapToClick: false, twoFingerScroll: false,
-                    reverseScrollDirection: false, sensitivity: 1.0, now: now)
+                    reverseScrollDirection: false, sensitivity: 1.0,
+                    pinchZoom: false, now: now)
             }
             return
         }
@@ -91,6 +92,7 @@ extension InputInjector {
             twoFingerScroll: snap.twoFingerScroll,
             reverseScrollDirection: snap.reverseScrollDirection,
             sensitivity: snap.touchSensitivity,
+            pinchZoom: snap.pinchZoomViaModifierWheel,
             now: now)
 
         switch intent {
@@ -102,6 +104,8 @@ extension InputInjector {
             postTouchScroll(
                 dx: dx, dy: dy, phase: phase,
                 usePhases: snap.twoFingerScrollMomentum)
+        case .zoomDelta(let dy, let phase):
+            postTouchZoom(dy: dy, phase: phase)
         case .tapClick:
             postTouchTapClick(snapshot: snap, settings: settings)
         }
@@ -153,6 +157,28 @@ extension InputInjector {
             e.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
         }
         e.flags = moveSafeEventFlags
+        finalizeAndPost(e)
+    }
+
+    /// Pinch-zoom stand-in: continuous pixel wheel with ⌃ set. Chromium /
+    /// Electron / Safari treat Ctrl+wheel as zoom (same as trackpad pinch
+    /// translation). No scroll phase — zoom consumers don't need the
+    /// trackpad Began/Changed/Ended envelope.
+    private func postTouchZoom(dy: Double, phase _: TouchStateTracker.ScrollPhase) {
+        // Began/Ended are zero-delta brackets; zoom only needs Changed frames.
+        guard dy != 0 else { return }
+        let loc = currentCursorPosition()
+        guard let e = CGEvent(
+            scrollWheelEvent2Source: sessionSource,
+            units: .pixel,
+            wheelCount: 1,
+            wheel1: Int32(dy.rounded()),
+            wheel2: 0,
+            wheel3: 0)
+        else { return }
+        e.location = loc
+        e.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
+        e.flags = moveSafeEventFlags.union(.maskControl)
         finalizeAndPost(e)
     }
 

--- a/MockTab/Driver/Injection/TouchStateTracker.swift
+++ b/MockTab/Driver/Injection/TouchStateTracker.swift
@@ -24,7 +24,15 @@ struct TouchStateTracker {
         case idle
         case pending        // contact(s) down, gesture not yet committed
         case pointer        // single contact moving the cursor
-        case scroll         // two contacts moving the scroll wheel
+        case scroll         // two contacts: pan scroll and/or pinch-zoom
+    }
+
+    /// Sticky two-finger sub-mode once significant motion is seen.
+    /// Pinch vs pan is chosen once per sequence (same sticky policy as Mode).
+    enum TwoFingerKind {
+        case undecided
+        case pan
+        case pinch
     }
 
     enum Intent: Equatable {
@@ -39,6 +47,10 @@ struct TouchStateTracker {
         /// (CG `kCGScrollWheelEventScrollPhase` values: 1=Began, 2=Changed,
         /// 4=Ended).  Sign convention follows the natural-scrolling setting.
         case scrollDelta(dx: Double, dy: Double, phase: ScrollPhase)
+        /// Pinch scale as a vertical wheel stand-in (posted with ⌃). Positive
+        /// `dy` follows CGEvent wheel1 "scroll up"; Chromium treats ⌃+wheel
+        /// as page zoom. Fingers spreading maps to zoom-in (negative `dy`).
+        case zoomDelta(dy: Double, phase: ScrollPhase)
     }
 
     enum ScrollPhase: Int {
@@ -70,6 +82,13 @@ struct TouchStateTracker {
     /// when the last contact lifts.
     private var lastScrollPhase: ScrollPhase = .ended
 
+    /// Sticky pan vs pinch once motion crosses `twoFingerDecideDistance`.
+    private var twoFingerKind: TwoFingerKind = .undecided
+    /// Last inter-finger distance in screen points (pinch tracking).
+    private var lastPinchDistance: Double = 0
+    /// True after this two-finger sequence emitted a zoom intent (for Ended).
+    private var pinchWasActive: Bool = false
+
     // MARK: - Tunables
 
     /// Maximum drift (in screen points) that still counts as a tap.
@@ -84,6 +103,12 @@ struct TouchStateTracker {
     /// having dragged the cursor in the meantime.  Same trick trackpads use;
     /// the cost is pointer motion starting ~0.1 s late.
     static let onsetDelay: CFAbsoluteTime = 0.12
+    /// Motion (screen points) needed to commit pan vs pinch for a sequence.
+    /// Slightly above finger-jitter so a sliding pan doesn't decide on noise.
+    static let twoFingerDecideDistance: Double = 6.0
+    /// Pinch wins only when inter-finger distance change clearly exceeds
+    /// centroid translation. Equal/noisy scale vs pan → stay pan (scroll).
+    static let pinchDominanceRatio: Double = 1.75
 
     // MARK: - Process
 
@@ -129,12 +154,14 @@ struct TouchStateTracker {
     /// `tapToClick` and `twoFingerScroll` gate the optional behaviours;
     /// `reverseScrollDirection` flips the sign of the scroll delta.
     /// `sensitivity` multiplies pointer-mode movement (1.0 = identity).
+    /// `pinchZoom` enables sticky pinch → ⌃+wheel zoom stand-in (vs pan scroll).
     mutating func process(
         contacts: [(id: Int, screen: CGPoint)],
         tapToClick: Bool,
         twoFingerScroll: Bool,
         reverseScrollDirection: Bool,
         sensitivity: Double,
+        pinchZoom: Bool = false,
         now: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()
     ) -> Intent {
 
@@ -144,11 +171,15 @@ struct TouchStateTracker {
         if contacts.isEmpty {
             let priorMode = mode
             let priorPhase = lastScrollPhase
+            let priorPinch = pinchWasActive
+            let priorKind = twoFingerKind
             let tap = tapToClick && (priorMode == .pointer || priorMode == .pending)
                 && now - tapStart <= Self.tapMaxDuration
                 && tapMaxDelta < Self.tapMaxDistance
             reset()
             switch priorMode {
+            case .scroll where priorPinch || priorKind == .pinch:
+                return .zoomDelta(dy: 0, phase: .ended)
             case .scroll where priorPhase != .ended:
                 return .scrollDelta(dx: 0, dy: 0, phase: .ended)
             case .pointer where tap, .pending where tap:
@@ -176,10 +207,19 @@ struct TouchStateTracker {
         if mode == .pending || mode == .pointer, contacts.count >= 2 {
             if twoFingerScroll {
                 mode = .scroll
+                let pair = Array(contacts.prefix(2))
                 lastPositions = Dictionary(uniqueKeysWithValues:
-                    contacts.prefix(2).map { ($0.id, $0.screen) })
+                    pair.map { ($0.id, $0.screen) })
                 tapAnchor = nil  // tap is off the table once we go to two fingers
                 lastScrollPhase = .began
+                twoFingerKind = pinchZoom ? .undecided : .pan
+                lastPinchDistance = Self.distance(between: pair)
+                pinchWasActive = false
+                // Defer Began until pan is committed when pinch discrimination
+                // is on — avoids opening a scroll phase that never gets deltas.
+                if pinchZoom {
+                    return .none
+                }
                 return .scrollDelta(dx: 0, dy: 0, phase: .began)
             } else if mode == .pointer {
                 // Two-finger scroll disabled: ignore the second contact,
@@ -217,11 +257,44 @@ struct TouchStateTracker {
             let tracked = current.filter { lastPositions[$0.id] != nil }
             let oldCentroid = centroid(of: tracked.compactMap { lastPositions[$0.id] })
             let newCentroid = centroid(of: tracked.map { $0.screen })
+            let newDistance = Self.distance(between: current)
+            let scaleDelta = newDistance - lastPinchDistance
             lastPositions = Dictionary(uniqueKeysWithValues:
                 current.map { ($0.id, $0.screen) })
+            lastPinchDistance = newDistance
             guard !tracked.isEmpty else { return .none }
             let dx = newCentroid.x - oldCentroid.x
             let dy = newCentroid.y - oldCentroid.y
+            let translation = hypot(dx, dy)
+
+            if pinchZoom {
+                if twoFingerKind == .undecided {
+                    let decide = Self.twoFingerDecideDistance
+                    if abs(scaleDelta) < decide, translation < decide {
+                        return .none
+                    }
+                    // Prefer pan unless pinch clearly dominates (ordinary pans
+                    // always have some finger-distance jitter).
+                    twoFingerKind =
+                        abs(scaleDelta) > translation * Self.pinchDominanceRatio
+                        ? .pinch : .pan
+                    if twoFingerKind == .pan {
+                        lastScrollPhase = .began
+                        return .scrollDelta(dx: 0, dy: 0, phase: .began)
+                    }
+                    lastScrollPhase = .began
+                    pinchWasActive = true
+                    return .zoomDelta(dy: 0, phase: .began)
+                }
+                if twoFingerKind == .pinch {
+                    if scaleDelta == 0 { return .none }
+                    // Fingers spreading (scaleDelta > 0) → zoom in → negative wheel.
+                    lastScrollPhase = .changed
+                    pinchWasActive = true
+                    return .zoomDelta(dy: -scaleDelta, phase: .changed)
+                }
+            }
+
             // Skip dead frames: a stationary palm with two contacts down would
             // otherwise post 100 no-op scroll events per second.
             if dx == 0 && dy == 0 { return .none }
@@ -256,6 +329,9 @@ struct TouchStateTracker {
         tapStart = 0
         tapMaxDelta = 0
         lastScrollPhase = .ended
+        twoFingerKind = .undecided
+        lastPinchDistance = 0
+        pinchWasActive = false
     }
 
     private func centroid(of points: [CGPoint]) -> CGPoint {
@@ -264,5 +340,12 @@ struct TouchStateTracker {
         let sx = points.reduce(0) { $0 + $1.x } / n
         let sy = points.reduce(0) { $0 + $1.y } / n
         return CGPoint(x: sx, y: sy)
+    }
+
+    private static func distance(between contacts: [(id: Int, screen: CGPoint)]) -> Double {
+        guard contacts.count >= 2 else { return 0 }
+        let a = contacts[0].screen
+        let b = contacts[1].screen
+        return hypot(a.x - b.x, a.y - b.y)
     }
 }

--- a/MockTab/Driver/Injection/TouchStateTracker.swift
+++ b/MockTab/Driver/Injection/TouchStateTracker.swift
@@ -86,6 +86,11 @@ struct TouchStateTracker {
     private var twoFingerKind: TwoFingerKind = .undecided
     /// Last inter-finger distance in screen points (pinch tracking).
     private var lastPinchDistance: Double = 0
+    /// Centroid / distance at the start of an undecided two-finger sequence.
+    /// Decision uses cumulative motion from these anchors, not per-frame deltas
+    /// (slow pans never exceed the threshold in a single high-rate frame).
+    private var undecidedOriginCentroid: CGPoint = .zero
+    private var undecidedOriginDistance: Double = 0
     /// True after this two-finger sequence emitted a zoom intent (for Ended).
     private var pinchWasActive: Bool = false
 
@@ -214,6 +219,8 @@ struct TouchStateTracker {
                 lastScrollPhase = .began
                 twoFingerKind = pinchZoom ? .undecided : .pan
                 lastPinchDistance = Self.distance(between: pair)
+                undecidedOriginCentroid = centroid(of: pair.map(\.screen))
+                undecidedOriginDistance = lastPinchDistance
                 pinchWasActive = false
                 // Defer Began until pan is committed when pinch discrimination
                 // is on — avoids opening a scroll phase that never gets deltas.
@@ -269,14 +276,20 @@ struct TouchStateTracker {
 
             if pinchZoom {
                 if twoFingerKind == .undecided {
+                    // Cumulative motion since two-finger sequence start — not
+                    // per-frame deltas, which stay tiny at high report rates.
+                    let cumTranslation = hypot(
+                        newCentroid.x - undecidedOriginCentroid.x,
+                        newCentroid.y - undecidedOriginCentroid.y)
+                    let cumScale = abs(newDistance - undecidedOriginDistance)
                     let decide = Self.twoFingerDecideDistance
-                    if abs(scaleDelta) < decide, translation < decide {
+                    if cumScale < decide, cumTranslation < decide {
                         return .none
                     }
                     // Prefer pan unless pinch clearly dominates (ordinary pans
                     // always have some finger-distance jitter).
                     twoFingerKind =
-                        abs(scaleDelta) > translation * Self.pinchDominanceRatio
+                        cumScale > cumTranslation * Self.pinchDominanceRatio
                         ? .pinch : .pan
                     if twoFingerKind == .pan {
                         lastScrollPhase = .began
@@ -331,6 +344,8 @@ struct TouchStateTracker {
         lastScrollPhase = .ended
         twoFingerKind = .undecided
         lastPinchDistance = 0
+        undecidedOriginCentroid = .zero
+        undecidedOriginDistance = 0
         pinchWasActive = false
     }
 

--- a/MockTab/Driver/Injection/TouchStateTracker.swift
+++ b/MockTab/Driver/Injection/TouchStateTracker.swift
@@ -272,7 +272,6 @@ struct TouchStateTracker {
             guard !tracked.isEmpty else { return .none }
             let dx = newCentroid.x - oldCentroid.x
             let dy = newCentroid.y - oldCentroid.y
-            let translation = hypot(dx, dy)
 
             if pinchZoom {
                 if twoFingerKind == .undecided {

--- a/MockTab/Driver/Injection/TouchStateTracker.swift
+++ b/MockTab/Driver/Injection/TouchStateTracker.swift
@@ -264,7 +264,11 @@ struct TouchStateTracker {
             let tracked = current.filter { lastPositions[$0.id] != nil }
             let oldCentroid = centroid(of: tracked.compactMap { lastPositions[$0.id] })
             let newCentroid = centroid(of: tracked.map { $0.screen })
-            let newDistance = Self.distance(between: current)
+            // Hold last distance when a finger lifts mid-gesture (1-contact
+            // frames). distance(between:) would be 0 and invent a huge scaleDelta.
+            let newDistance = current.count >= 2
+                ? Self.distance(between: current)
+                : lastPinchDistance
             let scaleDelta = newDistance - lastPinchDistance
             lastPositions = Dictionary(uniqueKeysWithValues:
                 current.map { ($0.id, $0.screen) })

--- a/MockTab/Settings/TabletSettings+Persistence.swift
+++ b/MockTab/Settings/TabletSettings+Persistence.swift
@@ -65,6 +65,7 @@ extension TabletSettings {
         twoFingerScroll = loadBool("twoFingerScroll", default: true)
         reverseScrollDirection = loadBool("naturalScrolling", default: false)
         twoFingerScrollMomentum = loadBool("twoFingerScrollMomentum", default: true)
+        pinchZoomViaModifierWheel = loadBool("pinchZoomViaModifierWheel", default: false)
         touchAreaX      = Swift.max(0.0,  Swift.min(loadDouble("touchAreaX",      default: 0.0), 1.0))
         touchAreaY      = Swift.max(0.0,  Swift.min(loadDouble("touchAreaY",      default: 0.0), 1.0))
         touchAreaWidth  = Swift.max(0.01, Swift.min(loadDouble("touchAreaWidth",  default: 1.0), 1.0))

--- a/MockTab/Settings/TabletSettings.swift
+++ b/MockTab/Settings/TabletSettings.swift
@@ -445,6 +445,12 @@ final class TabletSettings: ObservableObject {
     @Published var twoFingerScrollMomentum: Bool = true {
         didSet { persist("twoFingerScrollMomentum", twoFingerScrollMomentum) }
     }
+    /// When true (and two-finger scroll is on), a pinch gesture posts ⌃+wheel
+    /// events as a zoom stand-in for browsers/Electron. Off by default — pan
+    /// scroll stays the primary two-finger behaviour.
+    @Published var pinchZoomViaModifierWheel: Bool = false {
+        didSet { persist("pinchZoomViaModifierWheel", pinchZoomViaModifierWheel) }
+    }
     /// Active-touch-area mapping — independent from the pen's active area because
     /// users typically want the full surface for touch but a cropped area for pen
     /// work.  Coordinates are normalised 0..1 over the device's full touch surface.

--- a/MockTab/UI/Components/Features/AppOverrideBar.swift
+++ b/MockTab/UI/Components/Features/AppOverrideBar.swift
@@ -133,6 +133,7 @@ struct AppOverrideBar: View {
     static let touchKeys: Set<String> = [
         "touchEnabled", "tapToClick", "touchSensitivity",
         "twoFingerScroll", "naturalScrolling", "twoFingerScrollMomentum",
+        "pinchZoomViaModifierWheel",
         "touchAreaX", "touchAreaY", "touchAreaWidth", "touchAreaHeight",
     ]
 

--- a/MockTab/UI/Panes/TouchView.swift
+++ b/MockTab/UI/Panes/TouchView.swift
@@ -124,6 +124,17 @@ struct TouchView: View {
             .help("Two fingers moving together post smooth scroll events that apps treat as trackpad scrolling, including rubber-banding in Safari and Preview.")
 
             DescribedToggle(
+                "Pinch to Scroll",
+                isOn: settings.recordingBinding(
+                    String(localized: "Pinch to Scroll", comment: "Undo action name: pinch-to-zoom via Ctrl+wheel toggle in the Touch pane"),
+                    get: { settings.pinchZoomViaModifierWheel },
+                    set: { settings.pinchZoomViaModifierWheel = $0 }),
+                description: "Use two fingers to pinch and zoom in or out"
+            )
+            .disabled(!settings.touchEnabled || !settings.twoFingerScroll)
+            .help("Optional zoom stand-in: a pinch gesture injects continuous scroll-wheel events with the Control modifier. Safari, Chrome, and Electron treat that as page zoom. Does not synthesize native NSTouch / trackpad pinch.")
+
+            DescribedToggle(
                 "Reverse Direction",
                 isOn: settings.recordingBinding(
                     String(localized: "Scroll Direction", comment: "Undo action name: touch scroll-direction toggle in the Touch pane"),
@@ -256,6 +267,7 @@ struct TouchView: View {
     private typealias TouchState = (
         enabled: Bool, tapToClick: Bool, sensitivity: Double,
         twoFingerScroll: Bool, reverseScroll: Bool, twoFingerScrollMomentum: Bool,
+        pinchZoom: Bool,
         areaX: Double, areaY: Double, areaW: Double, areaH: Double
     )
 
@@ -263,10 +275,11 @@ struct TouchView: View {
         let old: TouchState = (
             settings.touchEnabled, settings.tapToClick, settings.touchSensitivity,
             settings.twoFingerScroll, settings.reverseScrollDirection, settings.twoFingerScrollMomentum,
+            settings.pinchZoomViaModifierWheel,
             settings.touchAreaX, settings.touchAreaY,
             settings.touchAreaWidth, settings.touchAreaHeight
         )
-        let defaults: TouchState = (false, false, 1.0, true, false, true, 0, 0, 1, 1)
+        let defaults: TouchState = (false, false, 1.0, true, false, true, false, 0, 0, 1, 1)
         applyTouchState(defaults, undoTo: old)
     }
 
@@ -276,6 +289,7 @@ struct TouchView: View {
         settings.undoManager?.beginUndoGrouping()
         (settings.touchEnabled, settings.tapToClick, settings.touchSensitivity,
          settings.twoFingerScroll, settings.reverseScrollDirection, settings.twoFingerScrollMomentum,
+         settings.pinchZoomViaModifierWheel,
          settings.touchAreaX, settings.touchAreaY,
          settings.touchAreaWidth, settings.touchAreaHeight) = new
         settings.record(String(localized: "Reset Pane to Defaults")) {

--- a/MockTab/UI/Panes/TouchView.swift
+++ b/MockTab/UI/Panes/TouchView.swift
@@ -124,12 +124,12 @@ struct TouchView: View {
             .help("Two fingers moving together post smooth scroll events that apps treat as trackpad scrolling, including rubber-banding in Safari and Preview.")
 
             DescribedToggle(
-                "Pinch to Scroll",
+                "Pinch to Zoom",
                 isOn: settings.recordingBinding(
-                    String(localized: "Pinch to Scroll", comment: "Undo action name: pinch-to-zoom via Ctrl+wheel toggle in the Touch pane"),
+                    String(localized: "Pinch to Zoom", comment: "Undo action name: pinch-to-zoom via Ctrl+wheel toggle in the Touch pane"),
                     get: { settings.pinchZoomViaModifierWheel },
                     set: { settings.pinchZoomViaModifierWheel = $0 }),
-                description: "Use two fingers to pinch and zoom in or out"
+                description: "Use two fingers to pinch and zoom in or out."
             )
             .disabled(!settings.touchEnabled || !settings.twoFingerScroll)
             .help("Optional zoom stand-in: a pinch gesture injects continuous scroll-wheel events with the Control modifier. Safari, Chrome, and Electron treat that as page zoom. Does not synthesize native NSTouch / trackpad pinch.")


### PR DESCRIPTION
Adds an optional Pinch to Zoom toggle right under Two-Finger Scroll in the Touch pane. It competes against the two-finger pan, and only when it is obvious the user is pinching does it zoom (Ctrl + scroll wheel equivalent).