### PR TITLE
Reject palm contacts that interrupt PTH-660 touch gestures

### DIFF
--- a/MockTab/Driver/Injection/InputInjector+Touch.swift
+++ b/MockTab/Driver/Injection/InputInjector+Touch.swift
@@ -58,12 +58,36 @@ extension InputInjector {
         let penBusy = lastProximity ||
             now - penProximityExitTime < Self.touchArbitrationGrace
         if penBusy {
+            touchPalmRejector.reset()
             if !contacts.isEmpty {
                 _ = touchTracker.process(
                     contacts: [], tapToClick: false, twoFingerScroll: false,
                     reverseScrollDirection: false, sensitivity: 1.0, now: now)
             }
             return
+        }
+
+        // Palm classification must happen before projection and gesture
+        // tracking. On the PTH-660 it preserves a simultaneous normal finger
+        // while dropping only the palm-sized contact; other tablets pass
+        // through unchanged until they have their own calibrated thresholds.
+        let filtered = touchPalmRejector.filter(
+            contacts: contacts.map {
+                (id: $0.id, major: $0.contactArea, minor: $0.contactMinor)
+            },
+            productID: deviceProductID)
+        let filteredContacts = contacts.filter { filtered.acceptedIDs.contains($0.id) }
+        if !filtered.newlyRejectedIDs.isEmpty || !filtered.newlyAcceptedIDs.isEmpty {
+            let rejected = contacts
+                .filter { filtered.newlyRejectedIDs.contains($0.id) }
+                .map { "\($0.id):\($0.contactArea ?? -1)/\($0.contactMinor ?? -1)" }
+                .joined(separator: ",")
+            let accepted = contacts
+                .filter { filtered.newlyAcceptedIDs.contains($0.id) }
+                .map { "\($0.id):\($0.contactArea ?? -1)/\($0.contactMinor ?? -1)" }
+                .joined(separator: ",")
+            injectLog.notice(
+                "touch palm filter: rejected=id:major/minor[\(rejected, privacy: .public)], accepted=id:major/minor[\(accepted, privacy: .public)]")
         }
 
         // Resolve display bounds — touch shares the pen's target display.
@@ -74,8 +98,8 @@ extension InputInjector {
         // and are dropped entirely (no clamping to the rect edge — that would
         // leave the deadzone partially responsive).
         var projected: [(id: Int, screen: CGPoint)] = []
-        projected.reserveCapacity(contacts.count)
-        for c in contacts {
+        projected.reserveCapacity(filteredContacts.count)
+        for c in filteredContacts {
             guard let p = TouchStateTracker.screenPoint(
                 for: c, maxX: cachedTouchMaxX, maxY: cachedTouchMaxY,
                 areaX: snap.touchAreaX, areaY: snap.touchAreaY,

--- a/MockTab/Driver/Injection/InputInjector.swift
+++ b/MockTab/Driver/Injection/InputInjector.swift
@@ -790,6 +790,9 @@ final class InputInjector: @unchecked Sendable {
 
     /// Mutable per-sequence state for capacitive touch.  HIDThread-owned.
     var touchTracker = TouchStateTracker()
+    /// Per-contact PTH-660 palm classification. HIDThread-owned alongside the
+    /// tracker, so a palm can never enter its gesture state.
+    var touchPalmRejector = TouchPalmRejector()
     /// CFAbsoluteTime when the pen last left proximity.  Touch is suppressed
     /// while the pen is in proximity and for a brief grace window after exit
     /// so palm-rejection bounces (finger contact arriving 1–2 frames after

--- a/MockTab/Driver/Injection/TouchStateTracker.swift
+++ b/MockTab/Driver/Injection/TouchStateTracker.swift
@@ -6,6 +6,101 @@ import CoreGraphics
 import Foundation
 import TabletKit
 
+/// Rejects palm-sized capacitive contacts before they reach gesture tracking.
+///
+/// PTH-660 reports the contact major axis for every touch slot. The units are
+/// device-specific, so this filter is deliberately limited to that calibrated
+/// family rather than applying an unsafe global threshold. A rejected slot
+/// remains rejected until it falls below a lower threshold or lifts, which
+/// keeps a noisy palm footprint from flapping into a finger gesture.
+struct TouchPalmRejector {
+
+    struct Result {
+        let acceptedIDs: Set<Int>
+        let newlyRejectedIDs: [Int]
+        let newlyAcceptedIDs: [Int]
+    }
+
+    /// PTH-660 USB and Bluetooth Classic PIDs. Injection normally sees the
+    /// canonical USB PID, but accepting both keeps the filter correct before
+    /// canonicalization and in isolated tests.
+    private static let pth660ProductIDs: Set<Int> = [0x0357, 0x0360]
+
+    /// Live PTH-660 capture: a palm begins at Width/Height 6/7, while the
+    /// finger-sized fragments alongside it remain 1–4. The descriptor's
+    /// logical maxima (41 × 31) are not physical millimetres, so a threshold
+    /// inferred from those maxima was invalid; use both observed raw axes.
+    private static let rejectAxisAtOrAbove = 5
+    /// A rejected contact only returns once both axes shrink below the
+    /// threshold, avoiding size-noise flapping during a palm contact.
+    private static let acceptAxisAtOrBelow = 3
+
+    private var rejectedIDs: Set<Int> = []
+
+    static func supports(productID: Int) -> Bool {
+        pth660ProductIDs.contains(productID)
+    }
+
+    private static func isPalm(major: Int?, minor: Int?) -> Bool {
+        [major, minor].compactMap { $0 }.contains { $0 >= rejectAxisAtOrAbove }
+    }
+
+    private static func isFingerSized(major: Int?, minor: Int?) -> Bool {
+        let axes = [major, minor].compactMap { $0 }
+        return !axes.isEmpty && axes.allSatisfy { $0 <= acceptAxisAtOrBelow }
+    }
+
+    mutating func filter(
+        contacts: [(id: Int, major: Int?, minor: Int?)],
+        productID: Int
+    ) -> Result {
+        guard Self.supports(productID: productID) else {
+            reset()
+            return Result(
+                acceptedIDs: Set(contacts.map(\.id)),
+                newlyRejectedIDs: [], newlyAcceptedIDs: [])
+        }
+
+        let activeIDs = Set(contacts.map(\.id))
+        rejectedIDs.formIntersection(activeIDs)
+
+        var acceptedIDs: Set<Int> = []
+        var newlyRejectedIDs: [Int] = []
+        var newlyAcceptedIDs: [Int] = []
+        acceptedIDs.reserveCapacity(contacts.count)
+
+        for contact in contacts {
+            if rejectedIDs.contains(contact.id) {
+                // A report missing its footprint must not let a previously
+                // classified palm back into an active gesture.
+                guard Self.isFingerSized(major: contact.major, minor: contact.minor) else {
+                    continue
+                }
+                rejectedIDs.remove(contact.id)
+                newlyAcceptedIDs.append(contact.id)
+                acceptedIDs.insert(contact.id)
+                continue
+            }
+
+            guard Self.isPalm(major: contact.major, minor: contact.minor) else {
+                acceptedIDs.insert(contact.id)
+                continue
+            }
+            rejectedIDs.insert(contact.id)
+            newlyRejectedIDs.append(contact.id)
+        }
+
+        return Result(
+            acceptedIDs: acceptedIDs,
+            newlyRejectedIDs: newlyRejectedIDs,
+            newlyAcceptedIDs: newlyAcceptedIDs)
+    }
+
+    mutating func reset() {
+        rejectedIDs.removeAll(keepingCapacity: true)
+    }
+}
+
 /// Translates a per-frame set of capacitive contacts into a single sticky-mode
 /// gesture intent (pointer drag vs. two-finger scroll vs. tap-click).
 ///

--- a/tools/touch-state-tracker-tests/TouchStateTrackerTests.swift
+++ b/tools/touch-state-tracker-tests/TouchStateTrackerTests.swift
@@ -29,27 +29,6 @@ private func expectEqual<T: Equatable>(
     )
 }
 
-private func contacts(distance: Double) -> [(id: Int, screen: CGPoint)] {
-    [(id: 1, screen: CGPoint(x: -distance / 2, y: 0)),
-     (id: 2, screen: CGPoint(x: distance / 2, y: 0))]
-}
-
-private func process(
-    _ tracker: inout TouchStateTracker,
-    _ contacts: [(id: Int, screen: CGPoint)],
-    at time: CFAbsoluteTime
-) -> TouchStateTracker.Intent {
-    tracker.process(
-        contacts: contacts,
-        tapToClick: false,
-        twoFingerScroll: true,
-        reverseScrollDirection: false,
-        sensitivity: 1,
-        pinchZoom: true,
-        now: time
-    )
-}
-
 private func rawContact(
     id: Int, major: Int?, minor: Int? = nil
 ) -> (id: Int, major: Int?, minor: Int?) {
@@ -89,35 +68,9 @@ private func testPalmFilteringIsPTH660Specific() {
                 "un-calibrated tablet families must keep their contacts unchanged")
 }
 
-private func testPinchWheelDirection() {
-    var tracker = TouchStateTracker()
-    _ = process(&tracker, [(id: 1, screen: .zero)], at: 0)
-    expectEqual(process(&tracker, contacts(distance: 20), at: 0.01), .none,
-                "two-finger pinch waits for a decisive motion")
-    expectEqual(process(&tracker, contacts(distance: 30), at: 0.02),
-                .zoomDelta(dy: 0, phase: .began),
-                "distance-dominant motion commits to pinch")
-    expectEqual(process(&tracker, contacts(distance: 34), at: 0.03),
-                .zoomDelta(dy: 4, phase: .changed),
-                "spreading fingers emits positive Ctrl-wheel for zoom-in")
-    expectEqual(process(&tracker, contacts(distance: 28), at: 0.04),
-                .zoomDelta(dy: -6, phase: .changed),
-                "closing fingers emits negative Ctrl-wheel for zoom-out")
-}
-
-private func testPreCommitLiftHasNoScrollEnd() {
-    var tracker = TouchStateTracker()
-    _ = process(&tracker, [(id: 1, screen: .zero)], at: 0)
-    _ = process(&tracker, contacts(distance: 20), at: 0.01)
-    expectEqual(process(&tracker, [], at: 0.02), .none,
-                "a pinch that never commits must not emit a scroll end")
-}
-
 @main
 enum TouchStateTrackerTestRunner {
     static func main() {
-        testPinchWheelDirection()
-        testPreCommitLiftHasNoScrollEnd()
         testPTH660PalmRejection()
         testPalmFilteringIsPTH660Specific()
 

--- a/tools/touch-state-tracker-tests/TouchStateTrackerTests.swift
+++ b/tools/touch-state-tracker-tests/TouchStateTrackerTests.swift
@@ -1,0 +1,131 @@
+// MockTab — native macOS driver for supported drawing tablets
+// SPDX-FileCopyrightText: 2026 Jay Petronis (Cyzor)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// TouchStateTrackerTests.swift — Standalone checks for touch gesture intent.
+//
+// The app has no XCTest target, so these run as a small executable compiled
+// against the real TouchStateTracker.swift. Run via
+// tools/touch-state-tracker-tests/run.sh. Exits non-zero on the first failure.
+
+import Foundation
+import TabletKit
+
+private var failures = 0
+private var checks = 0
+
+private func expectEqual<T: Equatable>(
+    _ actual: T,
+    _ expected: T,
+    _ message: @autoclosure () -> String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    checks += 1
+    guard actual != expected else { return }
+    failures += 1
+    FileHandle.standardError.write(
+        Data("FAIL (\(file):\(line)): \(message()) — got \(actual), expected \(expected)\n".utf8)
+    )
+}
+
+private func contacts(distance: Double) -> [(id: Int, screen: CGPoint)] {
+    [(id: 1, screen: CGPoint(x: -distance / 2, y: 0)),
+     (id: 2, screen: CGPoint(x: distance / 2, y: 0))]
+}
+
+private func process(
+    _ tracker: inout TouchStateTracker,
+    _ contacts: [(id: Int, screen: CGPoint)],
+    at time: CFAbsoluteTime
+) -> TouchStateTracker.Intent {
+    tracker.process(
+        contacts: contacts,
+        tapToClick: false,
+        twoFingerScroll: true,
+        reverseScrollDirection: false,
+        sensitivity: 1,
+        pinchZoom: true,
+        now: time
+    )
+}
+
+private func rawContact(
+    id: Int, major: Int?, minor: Int? = nil
+) -> (id: Int, major: Int?, minor: Int?) {
+    (id: id, major: major, minor: minor)
+}
+
+private func testPTH660PalmRejection() {
+    var rejector = TouchPalmRejector()
+
+    let initial = rejector.filter(
+        contacts: [rawContact(id: 1, major: 6, minor: 7), rawContact(id: 2, major: 2, minor: 3)],
+        productID: 0x0357)
+    expectEqual(initial.acceptedIDs, Set([2]),
+                "a palm must be dropped while a simultaneous finger remains usable")
+    expectEqual(initial.newlyRejectedIDs, [1],
+                "the live palm-sized PTH-660 contact must be classified as a palm")
+
+    let stillRejected = rejector.filter(
+        contacts: [rawContact(id: 1, major: 4, minor: 4), rawContact(id: 2, major: 2, minor: 3)],
+        productID: 0x0357)
+    expectEqual(stillRejected.acceptedIDs, Set([2]),
+                "hysteresis must keep a palm rejected between thresholds")
+
+    let accepted = rejector.filter(
+        contacts: [rawContact(id: 1, major: 3, minor: 3)], productID: 0x0357)
+    expectEqual(accepted.acceptedIDs, Set([1]),
+                "a contact below the lower threshold can return as a finger")
+    expectEqual(accepted.newlyAcceptedIDs, [1],
+                "the hysteresis release must be observable for logging")
+}
+
+private func testPalmFilteringIsPTH660Specific() {
+    var rejector = TouchPalmRejector()
+    let result = rejector.filter(
+        contacts: [rawContact(id: 1, major: 41)], productID: 0x0358)
+    expectEqual(result.acceptedIDs, Set([1]),
+                "un-calibrated tablet families must keep their contacts unchanged")
+}
+
+private func testPinchWheelDirection() {
+    var tracker = TouchStateTracker()
+    _ = process(&tracker, [(id: 1, screen: .zero)], at: 0)
+    expectEqual(process(&tracker, contacts(distance: 20), at: 0.01), .none,
+                "two-finger pinch waits for a decisive motion")
+    expectEqual(process(&tracker, contacts(distance: 30), at: 0.02),
+                .zoomDelta(dy: 0, phase: .began),
+                "distance-dominant motion commits to pinch")
+    expectEqual(process(&tracker, contacts(distance: 34), at: 0.03),
+                .zoomDelta(dy: 4, phase: .changed),
+                "spreading fingers emits positive Ctrl-wheel for zoom-in")
+    expectEqual(process(&tracker, contacts(distance: 28), at: 0.04),
+                .zoomDelta(dy: -6, phase: .changed),
+                "closing fingers emits negative Ctrl-wheel for zoom-out")
+}
+
+private func testPreCommitLiftHasNoScrollEnd() {
+    var tracker = TouchStateTracker()
+    _ = process(&tracker, [(id: 1, screen: .zero)], at: 0)
+    _ = process(&tracker, contacts(distance: 20), at: 0.01)
+    expectEqual(process(&tracker, [], at: 0.02), .none,
+                "a pinch that never commits must not emit a scroll end")
+}
+
+@main
+enum TouchStateTrackerTestRunner {
+    static func main() {
+        testPinchWheelDirection()
+        testPreCommitLiftHasNoScrollEnd()
+        testPTH660PalmRejection()
+        testPalmFilteringIsPTH660Specific()
+
+        if failures == 0 {
+            print("ok — \(checks) checks passed")
+            exit(0)
+        }
+        FileHandle.standardError.write(Data("\(failures) of \(checks) checks failed\n".utf8))
+        exit(1)
+    }
+}

--- a/tools/touch-state-tracker-tests/run.sh
+++ b/tools/touch-state-tracker-tests/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Compile and run touch-state intent checks against the real source file.
+# The app has no XCTest target, so this builds a small executable from
+# TouchStateTracker.swift plus the test main and runs it.
+set -e
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+SRC="$ROOT/MockTab/Driver/Injection/TouchStateTracker.swift"
+TEST="$DIR/TouchStateTrackerTests.swift"
+BIN="$(mktemp -d)/touch-state-tracker-tests"
+
+(
+  cd "$ROOT/TabletKit"
+  swift build --quiet
+)
+MODULES="$(find "$ROOT/TabletKit/.build" -type d -path '*/debug/Modules' -print -quit)"
+if [ -z "$MODULES" ]; then
+  echo "TabletKit Swift module was not built" >&2
+  exit 1
+fi
+OBJECTS="$(find "$ROOT/TabletKit/.build" -type f -path '*/debug/TabletKit.build/*.swift.o' -print)"
+if [ -z "$OBJECTS" ]; then
+  echo "TabletKit object files were not built" >&2
+  exit 1
+fi
+
+# Link TabletKit's object files as well as importing its module. Touch-state
+# tests now exercise palm classification, whose production API carries
+# TouchContact even though the test inputs are intentionally scalar.
+swiftc -O -I "$MODULES" "$SRC" "$TEST" $OBJECTS -o "$BIN"
+"$BIN"


### PR DESCRIPTION
## macOS version

N/A

## Tablet model

Wacom Intuos Pro M (PTH-660)

## Steps to reproduce

I noticed that palms were getting picked up and touch input larger than a standard finger was not being rejected. If you rest your hand while using your finger to pan, the palm interrupts panning or zooming with extra inputs. This PR fixes that issue.

1. Rest a palm on the tablet while using a finger to pan or zoom.
2. The palm creates extra touch contacts that enter gesture tracking.
3. The extra contacts interrupt or change the intended pan or zoom gesture.

Expected: Palm-sized contacts are ignored while smaller finger-sized contacts remain usable.

## Diagnostics

N/A

## Checklist

N/A

## Summary

- Palm-sized PTH-660 touch contacts were treated as normal touch input.
- Resting a hand while panning or zooming could add extra contacts and interrupt the gesture.

## Solution

- Preserve PTH-660 touch Width and Height values during decoding.
- Reject PTH-660 contacts when either observed axis is `>= 5`.
- Keep rejected contacts blocked until both axes are `<= 3`.
- Filter contacts before touch projection and gesture tracking.
- Leave other tablet families unchanged.

## Verification

- `tools/touch-state-tracker-tests/run.sh` passed, 6 focused checks.
- `swift test --package-path .Projects/tablet-driver/TabletKit` passed.
- Release MockTab build and code-signature verification passed.
- Live unified logs confirmed palm contacts were rejected before gesture injection.

## Scope

- PTH-660 USB and Bluetooth Classic touch input only.
- Other tablet families are unchanged.